### PR TITLE
Figroll missing requirements error message is mangled

### DIFF
--- a/lib/figroll.rb
+++ b/lib/figroll.rb
@@ -36,7 +36,7 @@ module Figroll
     return nil if (keys - required).length == keys.length - required.length
 
     missing = required.reject {|key| keys.include?(key)}
-    raise "Required variables not set: #{missing}"
+    raise "Required variables not set: #{missing.sort.join(', ')}"
   end
 
   def self.required

--- a/mock/multireqs.yml
+++ b/mock/multireqs.yml
@@ -1,0 +1,3 @@
+required:
+  - SAUSAGES
+  - GOLDERBLATS

--- a/spec/figroll_spec.rb
+++ b/spec/figroll_spec.rb
@@ -63,9 +63,24 @@ describe Figroll do
         end
 
         it 'raises an error' do
-          expect {load_file}.to raise_error
+          expect {load_file}.to raise_error("Required variables not set: SAUSAGES")
         end
       end
+
+      context 'multiple missing required variables' do
+        let(:filename) {'multireqs.yml'}
+
+        before(:each) do
+          ENV.delete('SAUSAGES')
+          ENV.delete('GOLDERBLATS')
+        end
+
+        it 'raises an error' do
+          expect {load_file}.to raise_error("Required variables not set: GOLDERBLATS, SAUSAGES")
+        end
+
+      end
+
 
       context 'and they are all present' do
         before(:each) do
@@ -89,6 +104,7 @@ describe Figroll do
         expect(load_file).to eql(nil)
       end
     end
+
   end
 
   describe '.fetch' do


### PR DESCRIPTION
When more than one missing variable is detected, the error message regarding those missing variables lacks separation between the variable names.

## Current Behavior ##

```gherkin
Given there's a required variable named "SAUSAGES"
And there's a required variable named "GOLDERBLATS"
And no required variable values are passed in
When the Fogroll config is loaded
Then I see an error message: "Required variables not set: GOLDERBLATSSAUSAGES"
```

## Desired Behavior ##

```gherkin
Given there's a required variable named "SAUSAGES"
And there's a required variable named "GOLDERBLATS"
And no required variable values are passed in
When the Fogroll config is loaded
Then I see an error message: "Required variables not set: GOLDERBLATS, SAUSAGES"
```